### PR TITLE
fix(maintainer): use caretaker-github distribution name

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install caretaker
         run: |
           VERSION=$(cat .github/maintainer/.version)
-          pip install "caretaker @ git+https://github.com/ianlintner/caretaker.git@v${VERSION}"
+          pip install "caretaker-github @ git+https://github.com/ianlintner/caretaker.git@v${VERSION}"
 
       - name: Run
         env:
@@ -104,7 +104,7 @@ jobs:
       - name: Install caretaker
         run: |
           VERSION=$(cat .github/maintainer/.version)
-          pip install "caretaker @ git+https://github.com/ianlintner/caretaker.git@v${VERSION}"
+          pip install "caretaker-github @ git+https://github.com/ianlintner/caretaker.git@v${VERSION}"
 
       - name: Self-heal — analyse own failure
         env:

--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install caretaker
         run: |
           VERSION=$(cat .github/maintainer/.version)
-          pip install "caretaker-github @ git+https://github.com/ianlintner/caretaker.git@v${VERSION}"
+          pip install "git+https://github.com/ianlintner/caretaker.git@v${VERSION}"
 
       - name: Run
         env:
@@ -104,7 +104,7 @@ jobs:
       - name: Install caretaker
         run: |
           VERSION=$(cat .github/maintainer/.version)
-          pip install "caretaker-github @ git+https://github.com/ianlintner/caretaker.git@v${VERSION}"
+          pip install "git+https://github.com/ianlintner/caretaker.git@v${VERSION}"
 
       - name: Self-heal — analyse own failure
         env:


### PR DESCRIPTION
The maintainer workflow installs caretaker with `pip install "caretaker @ git+..."`, but caretakers distribution metadata changed from `caretaker` to `caretaker-github` at v0.8.1, so pip now rejects the install on either side of the rename with:

> Requested <name> from git+.../caretaker.git@v<X> has inconsistent name: expected `<one>`, but metadata has `<other>`

Fix: drop the explicit distribution name from the install spec and install from the git URL alone, so pip accepts whatever name the pinned versions `pyproject.toml` declares. The same install line then works on every caretaker release the repo might pin to:

```
pip install "git+https://github.com/ianlintner/caretaker.git@v${VERSION}"
```

Upstream source-of-truth fix (setup template + skill): https://github.com/ianlintner/caretaker/pull/422

Generated with an automated cross-repo triage pass.